### PR TITLE
macOSのインストールスクリプトの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ macOSを利用している人向けの実行手順です。
 以下のコピーし、ターミナルに貼り付けて実行してください。
 
 ```bash
-curl -sf https://raw.githubusercontent.com/HazeyamaLab/system-design/master/macOS/install.sh | bash -s
+bash <(curl -sf https://raw.githubusercontent.com/HazeyamaLab/system-design/master/macOS/install.sh)
 ```
 
 #### 2.1. スクリプトの実行への同意

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -20,31 +20,33 @@ readonly LOGO='-----------------------------------------------------------------
 ##################################################
 # 実行確認関数
 function confirm_execution() {
-  read -rp ">> " input
-
-  if [ "$input" = 'y' ] || [ "$input" = 'Y' ]; then
-    return 0
-  elif [ "$input" = 'n' ] || [ "$input" = 'N' ]; then
-    echo "スクリプトを終了します."
-    exit 1
-  else
-    echo "y または n を入力して下さい."
-    confirm_execution
-  fi
+  while read -rp ">> " input
+  do
+    if [ "$input" = 'y' ] || [ "$input" = 'Y' ]; then
+      return 0
+    elif [ "$input" = 'n' ] || [ "$input" = 'N' ]; then
+      echo "スクリプトを終了します."
+      exit 1
+    else
+      echo "y または n を入力して下さい."
+      confirm_execution
+    fi
+  done
 }
 
 # 学籍番号確認関数
 function confirm_student_id() {
   echo "学籍番号を入力してください．"
   echo "例) a181401x"
-  read -rp ">> " ID
-
-  if [[ ! "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
-    echo "指定した形式で入力してください．"
-    confirm_student_id
-  else
-    return 0
-  fi
+  while read -rp ">> " ID
+  do
+    if [[ ! "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
+      echo "指定した形式で入力してください．"
+      confirm_student_id
+    else
+      return 0
+    fi
+  done
 }
 
 # Gradleのインストール関数(6.3をインストール後に6.2.2にする)

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -112,7 +112,7 @@ if which java >/dev/null 2>&1; then
   echo "[4/6] Java はインストール済みです. このステップはスキップします."
   CURRENT_JAVA_VERSION=$(java -version 2>&1)
   echo "[DEBUG] Java version: ${CURRENT_JAVA_VERSION}" >> "$LOG_OUT"
-  echo "[DEBUG] ENV JAVA_HOME:  ${JAVA_HOME}" >> "$LOG_OUT"
+  echo "[DEBUG] ENV JAVA_HOME: ${JAVA_HOME}" >> "$LOG_OUT"
 else
   echo "[4/6] Java をインストール中です..."
   brew tap homebrew/cask

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -20,7 +20,7 @@ readonly LOGO='-----------------------------------------------------------------
 ##################################################
 # 実行確認関数
 function confirm_execution() {
-  read -p ">> " input
+  read -rp ">> " input
 
   if [ "$input" = 'y' ] || [ "$input" = 'Y' ]; then
     return 0
@@ -37,7 +37,7 @@ function confirm_execution() {
 function confirm_student_id() {
   echo "学籍番号を入力してください．"
   echo "例) a181401x"
-  read -p ">> " ID
+  read -rp ">> " ID
 
   if [[ ! "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
     echo "指定した形式で入力してください．"

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# システム設計の環境構築用
-
 readonly LOGO='------------------------------------------------------------------------
                     __                        __          _           
    _______  _______/ /____  ____ ___     ____/ /__  _____(_)___ _____ 
@@ -24,10 +22,7 @@ readonly LOGO='-----------------------------------------------------------------
 function confirm_execution() {
   read -p ">> " input
 
-  if [ -z $input ] ; then
-    echo "y または n を入力して下さい."
-    confirm_execution
-  elif [ $input = 'y' ] || [ $input = 'Y' ]; then
+  if [ $input = 'y' ] || [ $input = 'Y' ]; then
     return 0
   elif [ $input = 'n' ] || [ $input = 'N' ]; then
     echo "スクリプトを終了します."
@@ -40,7 +35,6 @@ function confirm_execution() {
 
 # 学籍番号確認関数
 function confirm_student_id() {
-  
   echo "学籍番号を入力してください．"
   echo "例) a181401x"
   read -p ">> " ID
@@ -61,7 +55,6 @@ function install_gradle() {
   brew unlink gradle
   brew insatll gradle
 }
-
 
 ##################################################
 # main部分

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -22,9 +22,9 @@ readonly LOGO='-----------------------------------------------------------------
 function confirm_execution() {
   read -p ">> " input
 
-  if [ $input = 'y' ] || [ $input = 'Y' ]; then
+  if [ "$input" = 'y' ] || [ "$input" = 'Y' ]; then
     return 0
-  elif [ $input = 'n' ] || [ $input = 'N' ]; then
+  elif [ "$input" = 'n' ] || [ "$input" = 'N' ]; then
     echo "スクリプトを終了します."
     exit 1
   else
@@ -39,7 +39,7 @@ function confirm_student_id() {
   echo "例) a181401x"
   read -p ">> " ID
 
-  if [[ ! $ID =~ [a-z][0-9]{6}[a-z] ]]; then
+  if [[ ! "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
     echo "指定した形式で入力してください．"
     confirm_student_id
   else
@@ -79,7 +79,7 @@ echo "------------------------------------------------------------
 [INFO] ${DATE} User: ${ID}
 ------------------------------------------------------------
 ${OS_INFO}
-------------------------------------------------------------" >> $LOG_OUT
+------------------------------------------------------------" >> "$LOG_OUT"
 
 # Command Line Developper Toolsのインストール
 if which xcode-select >/dev/null 2>&1; then
@@ -101,7 +101,7 @@ fi
 if which mysql >/dev/null 2>&1; then
   echo "[3/6] MySQL はインストール済みです. このステップはスキップします."
   CURRENT_MYSQL_VERSION=$(mysql --version)
-  echo "[DEBUG] MySQL version: ${CURRENT_MYSQL_VERSION}" >> $LOG_OUT
+  echo "[DEBUG] MySQL version: ${CURRENT_MYSQL_VERSION}" >> "$LOG_OUT"
 else
   echo "[3/6] MySQL をインストール中です..."
   brew install mysql
@@ -111,8 +111,8 @@ fi
 if which java >/dev/null 2>&1; then
   echo "[4/6] Java はインストール済みです. このステップはスキップします."
   CURRENT_JAVA_VERSION=$(java -version 2>&1)
-  echo "[DEBUG] Java version: ${CURRENT_JAVA_VERSION}" >> $LOG_OUT
-  echo "[DEBUG] ENV JAVA_HOME:  ${JAVA_HOME}" >> $LOG_OUT
+  echo "[DEBUG] Java version: ${CURRENT_JAVA_VERSION}" >> "$LOG_OUT"
+  echo "[DEBUG] ENV JAVA_HOME:  ${JAVA_HOME}" >> "$LOG_OUT"
 else
   echo "[4/6] Java をインストール中です..."
   brew tap homebrew/cask
@@ -125,14 +125,14 @@ fi
 if which gradle >/dev/null 2>&1; then
   echo "[5/6] Gradle はインストール済みです. このステップはスキップします."
   CURRENT_GRADLE_VERSION=$(gradle -version)
-  echo "[DEBUG] Gradle version: ${CURRENT_GRADLE_VERSION}" >> $LOG_OUT
+  echo "[DEBUG] Gradle version: ${CURRENT_GRADLE_VERSION}" >> "$LOG_OUT"
 else
   echo "[5/6] Gradle をインストール中です..."
   install_gradle
 fi
 
 # ログデータの送信
-curl -fsSL -X POST https://hazelab-logger.netlify.app/.netlify/functions/send-teams -F "file=@${LOG_OUT}" >> $LOG_OUT
+curl -fsSL -X POST https://hazelab-logger.netlify.app/.netlify/functions/send-teams -F "file=@${LOG_OUT}" >> "$LOG_OUT"
 echo "[6/6] ログデータを送信しています..."
 
 echo "完了しました✨"

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -20,33 +20,30 @@ readonly LOGO='-----------------------------------------------------------------
 ##################################################
 # 実行確認関数
 function confirm_execution() {
-  while read -rp ">> " input
-  do
-    if [ "$input" = 'y' ] || [ "$input" = 'Y' ]; then
-      return 0
-    elif [ "$input" = 'n' ] || [ "$input" = 'N' ]; then
-      echo "スクリプトを終了します."
-      exit 1
-    else
-      echo "y または n を入力して下さい."
-      confirm_execution
-    fi
-  done
+  read -rp ">> " input
+  if [ "$input" = 'y' ] || [ "$input" = 'Y' ]; then
+    return 0
+  elif [ "$input" = 'n' ] || [ "$input" = 'N' ]; then
+    echo "スクリプトを終了します."
+    exit 1
+  else
+    echo "y または n を入力して下さい."
+    confirm_execution
+  fi
 }
 
 # 学籍番号確認関数
 function confirm_student_id() {
   echo "学籍番号を入力してください．"
   echo "例) a181401x"
-  while read -rp ">> " ID
-  do
-    if [[ ! "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
-      echo "指定した形式で入力してください．"
-      confirm_student_id
-    else
-      return 0
-    fi
-  done
+  read -rp ">> " ID
+
+  if [[ ! "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
+    echo "指定した形式で入力してください．"
+    confirm_student_id
+  else
+    return 0
+  fi
 }
 
 # Gradleのインストール関数(6.3をインストール後に6.2.2にする)

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -38,11 +38,11 @@ function confirm_student_id() {
   echo "例) a181401x"
   read -rp ">> " ID
 
-  if [[ ! "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
+  if [[ "$ID" =~ [a-z][0-9]{6}[a-z] ]]; then
+    return 0
+  else
     echo "指定した形式で入力してください．"
     confirm_student_id
-  else
-    return 0
   fi
 }
 

--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -70,7 +70,7 @@ confirm_student_id
 DEFAULT_PATH=$PWD
 FILE_NAME=$ID.log
 LOG_OUT="${DEFAULT_PATH}/${FILE_NAME}"
-exec 2>&1 > >(tee -a $LOG_OUT)
+exec 2>&1 > >(tee -a "$LOG_OUT")
 
 # ログファイルの先頭に実行日時などを記載
 DATE=$(date +"%Y/%m/%d %T")


### PR DESCRIPTION
## やったこと

- 条件分岐をwindowsのに合わせる
- 変数をダブルクォーテーションで囲う
- README.mdのスクリプトの実行手順を変更
