### PR TITLE
fix: Teamsでログデータが長すぎて見れない問題に対処

### DIFF
--- a/macOS/install.sh
+++ b/macOS/install.sh
@@ -65,55 +65,42 @@ echo "$LOGO"
 confirm_execution
 confirm_student_id
 
-# ログ出力の設定(今回は標準出力，標準エラー出力の両方を同じファイルに出力する)
+# ファイル出力の設定
 DEFAULT_PATH=$PWD
 FILE_NAME=$ID.log
 LOG_OUT="${DEFAULT_PATH}/${FILE_NAME}"
-exec 2>&1 > >(tee -a "$LOG_OUT")
-
-# ログファイルの先頭に実行日時などを記載
-DATE=$(date +"%Y/%m/%d %T")
-OS_INFO=$(sw_vers)
-echo "------------------------------------------------------------
-[INFO] ${DATE} User: ${ID}
-------------------------------------------------------------
-${OS_INFO}
-------------------------------------------------------------" >> "$LOG_OUT"
 
 # Command Line Developper Toolsのインストール
 if which xcode-select >/dev/null 2>&1; then
-  echo "[1/6] xcode-select はインストール済みです. このステップはスキップします."
+  echo "[1/7] xcode-select はインストール済みです. このステップはスキップします."
 else
-  echo "[1/6] xcode-select をインストール中です."
+  echo "[1/7] xcode-select をインストール中です."
   xcode-select --install
 fi
 
 # Homebrewのインストール
 if which brew >/dev/null 2>&1; then
-  echo "[2/6] homebrew はインストール済みです. このステップはスキップします."
+  echo "[2/7] homebrew はインストール済みです. このステップはスキップします."
 else
-  echo "[2/6] homebrew をインストール中です..."
+  echo "[2/7] homebrew をインストール中です..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 fi
 
 # MySQLのインストール
 if which mysql >/dev/null 2>&1; then
-  echo "[3/6] MySQL はインストール済みです. このステップはスキップします."
+  echo "[3/7] MySQL はインストール済みです. このステップはスキップします."
   CURRENT_MYSQL_VERSION=$(mysql --version)
   echo "[DEBUG] MySQL version: ${CURRENT_MYSQL_VERSION}" >> "$LOG_OUT"
 else
-  echo "[3/6] MySQL をインストール中です..."
+  echo "[3/7] MySQL をインストール中です..."
   brew install mysql
 fi
 
 # Javaのインストール
 if which java >/dev/null 2>&1; then
-  echo "[4/6] Java はインストール済みです. このステップはスキップします."
-  CURRENT_JAVA_VERSION=$(java -version 2>&1)
-  echo "[DEBUG] Java version: ${CURRENT_JAVA_VERSION}" >> "$LOG_OUT"
-  echo "[DEBUG] ENV JAVA_HOME: ${JAVA_HOME}" >> "$LOG_OUT"
+  echo "[4/7] Java はインストール済みです. このステップはスキップします."
 else
-  echo "[4/6] Java をインストール中です..."
+  echo "[4/7] Java をインストール中です..."
   brew tap homebrew/cask
   brew tap AdoptOpenJDK/openjdk
   brew cask adoptopenjdk/openjdk/adoptopenjdk8
@@ -122,16 +109,40 @@ fi
 
 # Gradleのインストール
 if which gradle >/dev/null 2>&1; then
-  echo "[5/6] Gradle はインストール済みです. このステップはスキップします."
-  CURRENT_GRADLE_VERSION=$(gradle -version)
-  echo "[DEBUG] Gradle version: ${CURRENT_GRADLE_VERSION}" >> "$LOG_OUT"
+  echo "[5/7] Gradle はインストール済みです. このステップはスキップします."
 else
-  echo "[5/6] Gradle をインストール中です..."
+  echo "[5/7] Gradle をインストール中です..."
   install_gradle
 fi
 
+##################################################
+# 環境情報の取得
+##################################################
+echo "[6/7] ソフトウェアのバージョンを確認しています..."
+
+DATE=$(date +"%Y/%m/%d %T")
+OS_INFO=$(sw_vers)
+echo "------------------------------------------------------------
+[INFO] ${DATE} User: ${ID}
+------------------------------------------------------------
+${OS_INFO}
+------------------------------------------------------------" >> "$LOG_OUT"
+
+# MySQLのバージョン
+CURRENT_MYSQL_VERSION=$(mysql --version)
+echo "[DEBUG] MySQL version: ${CURRENT_MYSQL_VERSION}" >> "$LOG_OUT"
+
+# Javaのバージョン
+CURRENT_JAVA_VERSION=$(java -version 2>&1)
+echo "[DEBUG] Java version: ${CURRENT_JAVA_VERSION}" >> "$LOG_OUT"
+echo "[DEBUG] ENV JAVA_HOME: ${JAVA_HOME}" >> "$LOG_OUT"
+
+# Gradleのバージョン
+CURRENT_GRADLE_VERSION=$(gradle -version)
+echo "[DEBUG] Gradle version: ${CURRENT_GRADLE_VERSION}" >> "$LOG_OUT"
+
 # ログデータの送信
-curl -fsSL -X POST https://hazelab-logger.netlify.app/.netlify/functions/send-teams -F "file=@${LOG_OUT}" >> "$LOG_OUT"
-echo "[6/6] ログデータを送信しています..."
+echo "[7/7] ログデータを送信しています..."
+curl -fsSL -X POST https://hazelab-logger.netlify.app/.netlify/functions/send-teams-from-mac -F "file=@${LOG_OUT}"
 
 echo "完了しました✨"

--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -55,64 +55,68 @@ Write-Host "$LOGG"
 Confirm-Execution
 [string]$ID = Confirm-StudentID
 
-# ログファイルの作成に使用するので実行時のパスを取得
+# ファイルの作成に使用するので実行時のパスを取得
 [string]$DefaultPath = Convert-Path .
 
 # scoopのインストール
 if (gcm scoop -ea SilentlyContinue) {
-  Write-Host "[1/7] scoop はインストール済みです. このステップはスキップします."
+  Write-Host "[1/8] scoop はインストール済みです. このステップはスキップします."
 } else {
-  Write-Host "[1/7] scoop をインストールしています..."
+  Write-Host "[1/8] scoop をインストールしています..."
   Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 }
 
 # chocolateyのインストール
 if (gcm choco -ea SilentlyContinue) {
-  Write-Host "[2/7] chocolatey はインストール済みです. このステップはスキップします."
+  Write-Host "[2/8] chocolatey はインストール済みです. このステップはスキップします."
 } else {
-  Write-Host "[2/7] chocolatey をインストールしています..."
+  Write-Host "[2/8] chocolatey をインストールしています..."
   Set-ExecutionPolicy Bypass -Scope Process -Force;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 }
 
 # Gitのインストール
 if (gcm git -ea SilentlyContinue) {
-  Write-Host "[3/7] git はインストール済みです. このステップはスキップします."
+  Write-Host "[3/8] git はインストール済みです. このステップはスキップします."
 } else {
-  Write-Host "[3/7] git をインストールしています..."
+  Write-Host "[3/8] git をインストールしています..."
   scoop install git
 }
 
 # scoopの設定(これにGitが必要)
+# todo: 条件分岐
 scoop bucket add extras
 scoop bucket add java
 
 # MySQLのインストール
 if (gcm mysql -ea SilentlyContinue) {
-  Write-Host "[4/7] MySQL はインストール済みです. このステップはスキップします."
-} else {
-  Write-Host "[4/7] MySQL をインストールしています..."
+  Write-Host "[4/8] MySQL はインストール済みです. このステップはスキップします."} else {
+  Write-Host "[4/8] MySQL をインストールしています..."
   choco install -y mysql
   scoop install mysql-workbench
 }
 
 # Javaのインストール
 if (gcm java -ea SilentlyContinue) {
-  Write-Host "[5/7] Java はインストール済みです. このステップはスキップします."
+  Write-Host "[5/8] Java はインストール済みです. このステップはスキップします."
 } else {
-  Write-Host "[5/7] Java をインストールしています..."
+  Write-Host "[5/8] Java をインストールしています..."
   scoop install adopt8-hotspot
   scoop install adopt11-hotspot
 }
 
 # Gradleのインストール
 if (gcm gradle -ea SilentlyContinue) {
-  Write-Host "[6/7] Gradle はインストール済みです. このステップはスキップします."
+  Write-Host "[6/8] Gradle はインストール済みです. このステップはスキップします."
 } else {
-  Write-Host "[6/7] Gradle をインストールしています..."
+  Write-Host "[6/8] Gradle をインストールしています..."
   scoop install gradle@6.2.2
 }
 
-# インストール後の環境の情報をログファイルに記録
+##################################################
+# 環境情報の取得
+##################################################
+Write-Host "[7/8] ソフトウェアのバージョンを確認しています..."
+
 Start-Transcript "$DefaultPath/$ID.log"
 
 Write-Host "[DEBUG] MySQLのバージョンを確認します."
@@ -131,7 +135,7 @@ gradle -version
 Stop-Transcript
 
 # ログデータの送信
+Write-Host "[8/8] ログデータを送信しています..."
 Invoke-WebRequest -Method Post -InFile "$DefaultPath/$ID.log" https://hazelab-logger.netlify.app/.netlify/functions/send-teams
-Write-Host "[7/7] ログデータを送信しています..."
 
 Write-Host "完了しました✨"


### PR DESCRIPTION
## やったこと

- ログデータを全て送ると長すぎて見れない問題に対処
- 必要なログは何か？ => ソフトウェアのバージョンがわかれば問題なさそう🤔
という感じでソフトウェアのバージョンを確認するステップを入れてその部分のログだけを収集することにした．

## 残タスク

- windowsのscoopのセットアップが2回目以降に行われないように制御する．